### PR TITLE
feat: add Concentrate AI as preferred LLM summarization backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ End-of-day recap for AI-assisted coding sessions. Reads your local conversations
 - Scans completed AI coding sessions from your local machine (nothing leaves your machine unless you enable LLM summaries)
 - Shows tokens used, estimated cost, duration, and models per session
 - Groups sessions by project and shows git commits alongside
-- Optionally generates first-person standup messages via OpenAI or Anthropic
+- Optionally generates first-person standup messages via [Concentrate AI](https://concentrate.ai/?utm_source=fzm&utm_medium=gh&utm_campaign=ujhj), OpenAI, or Anthropic
 
 ## Supported tools
 
@@ -55,9 +55,17 @@ devday -v                     # debug output
 Summaries are optional. Without an API key, devday shows stats and git only.
 
 ```bash
-export OPENAI_API_KEY=sk-...      # or
+export CONCENTRATE_API_KEY=sk-cn-...   # recommended
+# or
+export OPENAI_API_KEY=sk-...
 export ANTHROPIC_API_KEY=sk-...
 ```
+
+### Concentrate AI (recommended)
+
+[Concentrate AI](https://concentrate.ai/?utm_source=fzm&utm_medium=gh&utm_campaign=ujhj) is a unified LLM gateway that routes to 50+ models (GPT-5, Claude, Gemini, etc.) through a single API key. devday uses it with `gpt-5-mini` for fast, cheap summarization.
+
+**$20 in free credits** when you [sign up](https://concentrate.ai/?utm_source=fzm&utm_medium=gh&utm_campaign=ujhj) — more than enough to run devday for months.
 
 ## How it works
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,21 +34,24 @@ function detectAvailableTools(): ToolName[] {
 
 /**
  * Load config purely from environment variables + auto-detection.
- * API keys come from env vars only (OPENAI_API_KEY, ANTHROPIC_API_KEY).
+ * API keys come from env vars only (CONCENTRATE_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY).
  * Tool paths are auto-detected. Non-sensitive preferences can be saved to config file.
  */
 export function loadConfig(): DevDayConfig {
   const paths = getDefaultPaths();
 
+  const concentrateKey = process.env.CONCENTRATE_API_KEY ?? null;
   const anthropicKey = process.env.ANTHROPIC_API_KEY ?? null;
   const openaiKey = process.env.OPENAI_API_KEY ?? null;
 
-  // Prefer OpenAI (cheaper for summarization), fall back to Anthropic
-  let preferredSummarizer: 'anthropic' | 'openai' | 'none' = 'none';
-  if (openaiKey) preferredSummarizer = 'openai';
+  // Prefer Concentrate (unified gateway, auto-routing), then OpenAI, then Anthropic
+  let preferredSummarizer: 'concentrate' | 'anthropic' | 'openai' | 'none' = 'none';
+  if (concentrateKey) preferredSummarizer = 'concentrate';
+  else if (openaiKey) preferredSummarizer = 'openai';
   else if (anthropicKey) preferredSummarizer = 'anthropic';
 
   const defaults: DevDayConfig = {
+    concentrateApiKey: concentrateKey,
     anthropicApiKey: anthropicKey,
     openaiApiKey: openaiKey,
     preferredSummarizer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,9 +107,10 @@ export interface DayRecap {
 // ── Config ───────────────────────────────────────────────────────
 export interface DevDayConfig {
   // API keys for summarization
+  concentrateApiKey: string | null;
   anthropicApiKey: string | null;
   openaiApiKey: string | null;
-  preferredSummarizer: 'anthropic' | 'openai' | 'none';
+  preferredSummarizer: 'concentrate' | 'anthropic' | 'openai' | 'none';
 
   // Tool-specific paths (auto-detected, user-overridable)
   paths: {


### PR DESCRIPTION
- Add CONCENTRATE_API_KEY support as the recommended provider for summaries
- Use gpt-5-mini via Concentrate's unified gateway with reasoning effort: low
- Proper error handling: surface auth failures, rate limits, timeouts, and malformed responses as user-visible warnings instead of silent null returns
- Early abort: skip standup generation if all project summaries fail
- Pass logger through to summarize functions for verbose debug output
- Update help text and CLI prompts to mention CONCENTRATE_API_KEY
- Update README with Concentrate AI docs and signup link